### PR TITLE
Fix reflection exception on restore backup

### DIFF
--- a/omada-controller.service
+++ b/omada-controller.service
@@ -6,7 +6,7 @@ After=network.target
 User=omada
 Group=omada
 WorkingDirectory=/opt/omada-controller
-ExecStart=/usr/bin/jsvc -nodetach -cwd /opt/omada-controller/lib -pidfile /dev/null -home /usr/lib/jvm/default -cp /usr/share/java/commons-daemon.jar:/opt/omada-controller/lib/*:/opt/omada-controller/properties -outfile SYSLOG -errfile SYSLOG -procname omada-controller -showversion -server -Xms128m -Xmx1024m -XX:MaxHeapFreeRatio=60 -XX:MinHeapFreeRatio=30 -XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true com.tplink.smb.omada.starter.OmadaLinuxMain start
+ExecStart=/usr/bin/jsvc -nodetach -cwd /opt/omada-controller/lib -pidfile /dev/null -home /usr/lib/jvm/default -cp /usr/share/java/commons-daemon.jar:/opt/omada-controller/lib/*:/opt/omada-controller/properties -outfile SYSLOG -errfile SYSLOG -procname omada-controller -showversion -server -Xms128m -Xmx1024m -XX:MaxHeapFreeRatio=60 -XX:MinHeapFreeRatio=30 -XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true com.tplink.smb.omada.starter.OmadaLinuxMain start  --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.rmi sun.rmi.transport=ALL-UNNAMED --add-opens=java.base/java.math=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.sql/java.sql=ALL-UNNAMED --add-opens=java.base java.lang.reflect=ALL-UNNAMED
 ProtectHome=true
 
 [Install]


### PR DESCRIPTION
This PR fixes the issue reported [here](https://community.tp-link.com/en/business/forum/topic/643966)

The standard java startup command makes the program break when the user uses the restore function to import a backup during initial configuration.

The exception is comething like this:

```
 [restore-work-group-0] [] c.t.s.o.b.c.r.c(): omadacId=OmadacId(XXX) restore failed with Exception
java.lang.reflect.InaccessibleObjectException: Unable to make field private static final long java.util.LinkedHashMap.serialVersionUID accessible: module java.base does not "opens java.util" to unnamed module
```

Adding some more options fix the issue. Besides that, omada-controller will still require jdk11 in order to run with no exceptions.